### PR TITLE
re-enable compress css

### DIFF
--- a/django_project/solid_theme/templates/base.html
+++ b/django_project/solid_theme/templates/base.html
@@ -14,12 +14,13 @@
 <link rel="alternate" type="application/rss+xml" title="RSS" href="{% url "blog_post_feed" "rss" %}">
 <link rel="alternate" type="application/atom+xml" title="Atom" href="{% url "blog_post_feed" "atom" %}">
 {% endifinstalled %}
+<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,700,600,800' rel='stylesheet' type='text/css'>
+{% compress css %}
 <link rel="stylesheet" href="{% static "css/fonts.css" %}">
 <link rel="stylesheet" href="{% static "css/bootstrap.css" %}">
 <link rel="stylesheet" href="{% static "css/mezzanine.css" %}">
 <link href="{% static "css/font-awesome.min.css" %}" rel="stylesheet" type="text/css" />
 <link href="{% static "css/style.css" %}" rel="stylesheet">
-<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,700,600,800' rel='stylesheet' type='text/css'>
 {% if LANGUAGE_BIDI %}
 <link rel="stylesheet" href="{% static "css/rtl.css" %}">
 {% endif %}
@@ -30,7 +31,6 @@
 {% endif %}
 {% endifinstalled %}
 {% block extra_css %}{% endblock %}
-{% compress css %}
 {% endcompress %}
 
 {% compress js %}


### PR DESCRIPTION
@timlinux 

it seems that compress css just can handle local css

_disable_
![screenshot from 2016-08-11 12 41 03](https://cloud.githubusercontent.com/assets/4530905/17579778/cd035aac-5fc2-11e6-9882-d31ba04c8243.png)

_enable_
![screenshot from 2016-08-11 12 41 31](https://cloud.githubusercontent.com/assets/4530905/17579779/cd0b0798-5fc2-11e6-9ef6-e02a449f7b86.png)

this fix #9 
