### PR TITLE
fixing bug on csrf issue from keywords_field

### DIFF
--- a/django_project/core/base_static/mezzanine/js/admin/keywords_field.js
+++ b/django_project/core/base_static/mezzanine/js/admin/keywords_field.js
@@ -1,0 +1,61 @@
+jQuery(function ($) {
+
+    $('.keywords-field').css(window.__grappelli_installed ?
+    {margin: '5px 0 0 130px', width: '700px'} :
+    {margin: '5px 0 0 75px', width: '620px'});
+
+    // Add click functionality to each keyword so that it toggles
+    // the keyword's existance in the associated input box.
+    $('.keywords-field a').click(function () {
+        var field = $(this).parent().prev('input[type=text]');
+        var keywords = $.map(field.attr('value').split(','), function (keyword) {
+            return $.trim(keyword);
+        });
+        var keywords = $.grep(keywords, function (keyword) {
+            return keyword.length > 0;
+        });
+        var op, keyword = $(this).text().substr(1);
+        if ($.inArray(keyword, keywords) >= 0) {
+            keywords = $.grep(keywords, function (keep) {
+                return keep != keyword;
+            });
+            op = '+';
+        } else {
+            keywords[keywords.length] = keyword;
+            op = '-';
+        }
+        field.attr('value', keywords.join(', '))
+        $(this).text(op + keyword);
+        //return false;
+    });
+
+    // When submitting the form, go through each of the keywords
+    // fields and post their keywords via AJAX, to retrieve a list of
+    // keyword IDs for storing in each of the associated hidden fields.
+    var keywordsSaved = false;
+    $('input[type=submit]').click(function () {
+        if (keywordsSaved) {
+            return true;
+        }
+        var button = $(this);
+        var fields = $.makeArray($('.keywords-field').prev('input[type=text]'));
+        var submitKeywords = function () {
+            var field = fields.shift();
+            var keywords = {text_keywords: field.value};
+            $.post(window.__admin_keywords_submit_url, keywords, function (data) {
+                var ids = data.split("|")[0].split(',');
+                field.value = data.split("|")[1];
+                $(field).prev('input').attr('value', ids);
+                if (fields.length > 0) {
+                    submitKeywords();
+                } else {
+                    keywordsSaved = true;
+                    button.click();
+                }
+            });
+        };
+        submitKeywords();
+        //return false;
+    });
+
+});

--- a/django_project/core/templates/admin/base_site.html
+++ b/django_project/core/templates/admin/base_site.html
@@ -1,0 +1,13 @@
+{% extends "admin/base.html" %}
+
+{% block title %}{{ title }} | {{ site_title|default:_('Django site admin') }}{% endblock %}
+
+{% block extrahead %}
+    <script src="//code.jquery.com/jquery-1.11.3.min.js"></script>
+{% endblock %}
+
+{% block branding %}
+    <h1 id="site-name"><a href="{% url 'admin:index' %}">{{ site_header|default:_('Django administration') }}</a></h1>
+{% endblock %}
+
+{% block nav-global %}{% endblock %}


### PR DESCRIPTION
@timlinux 
this fix #16 
It was a bit tricky
1. Admin doesn't provide jQuery, instead djangoQuery that makes rich text widget cannot rendered
2. After it is solved, csrf issue is up again. Found that the problem is from static/js/mezzanine/admin/keywords_field.js.
3. so i override keywords_field to solve it

![screenshot from 2016-08-15 16 38 13](https://cloud.githubusercontent.com/assets/4530905/17661497/c4cc21a8-6309-11e6-96a4-22df078d762c.png)
![screenshot from 2016-08-15 16 38 19](https://cloud.githubusercontent.com/assets/4530905/17661498/c4e7479e-6309-11e6-8edb-e79e20e96683.png)
![screenshot from 2016-08-15 16 38 22](https://cloud.githubusercontent.com/assets/4530905/17661499/c556a882-6309-11e6-838f-c2b235801d16.png)
