### PR TITLE
fixing failed container db

### DIFF
--- a/deployment/Makefile
+++ b/deployment/Makefile
@@ -45,7 +45,6 @@ permissions:
 	@if [ -d "logs" ]; then sudo chmod -R a+rwx logs; fi
 	@if [ -d "media" ]; then sudo chmod -R a+rwx media; fi
 	@if [ -d "static" ]; then sudo chmod -R a+rwx static; fi
-	@if [ -d "pg" ]; then sudo chmod -R a+rwx pg; fi
 	@if [ -d "backups" ]; then sudo chmod -R a+rwx backups; fi
 
 db:


### PR DESCRIPTION
@timlinux 
when container db restart, it seems that container cannot restarted again due to pg permission, and the container will be a zombie container.
i think because of the permission in makefile?

tested
