### PR TITLE
Put all url inside i18n_patterns

### DIFF
--- a/django_project/core/urls.py
+++ b/django_project/core/urls.py
@@ -26,17 +26,22 @@ admin.autodiscover()
 # You can also change the ``home`` view to add your own functionality
 # to the project's homepage.
 
-urlpatterns = i18n_patterns("",
+urlpatterns = i18n_patterns(
+    '',
+
     # Change the admin prefix here to use an alternate URL for the
     # admin interface, which would be marginally more secure.
     ("^admin/", include(admin.site.urls)),
+
     # For mezzanine-people
     ("^people/", include('mezzanine_people.urls')),
     ("^api/people/", "core.views.get_all_people"),
-    ("^careers/", include("careers.urls")),
-)
 
-urlpatterns += patterns('',
+    # Mezzanine Careers
+    ("^careers/", include("careers.urls")),
+
+    # For mezzanine-agenda
+    ("^%s/" % settings.EVENT_SLUG, include("mezzanine_agenda.urls")),
 
     # We don't want to presume how your homepage works, so here are a
     # few patterns you can use to set it up.
@@ -104,8 +109,6 @@ urlpatterns += patterns('',
 
     # ("^%s/" % settings.SITE_PREFIX, include("mezzanine.urls"))
 
-    # For mezzanine-agenda
-    ("^%s/" % settings.EVENT_SLUG, include("mezzanine_agenda.urls")),
 )
 
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
Fix #74 

It appears there is an inconsistency on the url management, some of them using i18n pattern, some not. I put all urls inside i18n now.
