### PR TITLE
fix featured image doesn't show

### DIFF
--- a/django_project/mezzanine_agenda/templates/agenda/event_detail.html
+++ b/django_project/mezzanine_agenda/templates/agenda/event_detail.html
@@ -62,7 +62,7 @@
 {% endblock %}
 
 {% block event_detail_featured_image %}
-{% if settings.EVENT_USE_FEATURED_IMAGE and event.featured_image %}
+{% if event.featured_image %}
 <p><img class="img-responsive" src="{{ MEDIA_URL }}{% thumbnail event.featured_image 600 0 %}"></p>
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
@gubuntu @timlinux 
this fix #119 

![selection_004](https://cloud.githubusercontent.com/assets/4530905/18265894/21a7a4d0-7442-11e6-8591-639677e7c585.png)

note : i reuploaded random image to test it. It seems some folder on mountain rejected when mediasync

```
rsync: mkstemp "/home/meomancer/Development/docker-mezzanine/deployment/media/uploads/galleries/events/Open_GIS_and_data_day/.imag4572.jpg.uw8S4q" failed: Permission denied (13)
      1,948,391 100%  118.76kB/s    0:00:16 (xfr#1, to-chk=178/197)
rsync: mkstemp "/home/meomancer/Development/docker-mezzanine/deployment/media/uploads/galleries/events/Open_GIS_and_data_day/.imag4573.jpg.LjK03Q" failed: Permission denied (13)
        183,537 100%  103.72kB/s    0:00:01 (xfr#2, to-chk=177/197)
```
