### PR TITLE
Hide draft and add a setting

### DIFF
--- a/deployment/docker/REQUIREMENTS.txt
+++ b/deployment/docker/REQUIREMENTS.txt
@@ -1,7 +1,7 @@
 celery
 Django>=1.8,<1.9
 psycopg2
-mezzanine
+git+https://github.com/dimasciput/mezzanine.git@develop
 mezzanine_people
 mezzanine-references
 mezzanine-mdown

--- a/django_project/kartoza_theme/templates/mezzanine_people/person_list.html
+++ b/django_project/kartoza_theme/templates/mezzanine_people/person_list.html
@@ -56,8 +56,8 @@
                     <div class="text-wrapper" onclick="location.href='/people/person/{{ person.slug }}'">
                         {% if person.bio %}
                         <div class="person-bio">
-                            {{ person.bio|richtext_filter|safe|truncatechars:250 }}
-                            {% if person.bio|length > 180 %}
+                            {{ person.bio|safe|truncatechars:250 }}
+                            {% if person.bio|length > 250 %}
                                 <a href="/people/person/{{ person.slug }}">[see more]</a>
                             {% endif %}
                         </div>


### PR DESCRIPTION
Fix https://github.com/kartoza/docker-mezzanine/issues/147

Add hide draft setting under Miscellaneous, draft will be hidden in default.
![1](https://cloud.githubusercontent.com/assets/1979569/18774109/f57669dc-817f-11e6-8d79-b3f19b7f13ef.png)
