### PR TITLE
changing cartridge to forked upstream

### DIFF
--- a/deployment/docker/REQUIREMENTS.txt
+++ b/deployment/docker/REQUIREMENTS.txt
@@ -14,8 +14,8 @@ git+https://github.com/dimasciput/mezzanine-careers.git@develop
 git+https://github.com/meomancer/mezzanine-modal-announcements.git@develop
 git+https://github.com/meomancer/mezzanine-file-collections.git@master
 git+https://github.com/meomancer/django-wms-client.git@mezzanine
+git+https://github.com/meomancer/cartridge.git@develop
 mezzanine-slides
-cartridge
 # Raven pinned to 3.3.7 - see
 # https://github.com/getsentry/raven-python/issues/337
 raven==5.8.1


### PR DESCRIPTION
@gubuntu this fix kartoza/kartoza.com#183
Is it already right behaviour?
Note, that field just show if we set tax type as "vat"
So, if user doesn't set tax type as vat, this fields will not show.

![selection_002](https://cloud.githubusercontent.com/assets/4530905/18777706/d5e452e4-819a-11e6-978d-7ee377ea2585.png)
![selection_003](https://cloud.githubusercontent.com/assets/4530905/18777707/d5eef686-819a-11e6-9bf2-7bf0ea19f189.png)

I updated upstream because it has to saved to models and has to update the upstream's model
https://github.com/meomancer/cartridge/commit/1e12627f86387e578164570522dc43f8916067da
