### PR TITLE
remove django.security.disallowehost

### DIFF
--- a/django_project/core/settings/base.py
+++ b/django_project/core/settings/base.py
@@ -174,12 +174,6 @@ LOGGING = {
         }
     },
     'loggers': {
-        # Special rules to not bother logging when host is
-        # not allowed otherwise we get lots of mail spam....
-        'django.security.DisallowedHost': {
-            'handlers': ['null'],
-            'propagate': False,
-        },
         'django.request': {
             'handlers': ['mail_admins'],
             'level': 'ERROR',

--- a/django_project/core/settings/prod.py
+++ b/django_project/core/settings/prod.py
@@ -81,12 +81,6 @@ if 'raven.contrib.django.raven_compat' in INSTALLED_APPS:
             }
         },
         'loggers': {
-            # Special rules to not bother logging when host is
-            # not allowed otherwise we get lots of mail spam....
-            'django.security.DisallowedHost': {
-                'handlers': ['null'],
-                'propagate': False,
-            },
             'django.db.backends': {
                 'level': 'ERROR',
                 'handlers': ['console'],


### PR DESCRIPTION
removes django.security.disallowehost because it has generated an error.