### PR TITLE
update project order

### DIFF
--- a/django_project/kartoza_project/admin.py
+++ b/django_project/kartoza_project/admin.py
@@ -1,5 +1,7 @@
 from django.contrib import admin
 from django.conf import settings
+from django import forms
+from django.forms import ModelForm
 from kartoza_project.models import (
     Project,
     ProjectImage,
@@ -23,13 +25,22 @@ class ReferenceStackedInline(admin.StackedInline):
     extra = 1
 
 
+class ProjectAdminForm(ModelForm):
+    _order = forms.IntegerField(required=False)
+
+    class Meta:
+        model = Project
+        exclude = []
+
+
 class ProjectAdmin(admin.ModelAdmin):
     """
     Admin class for project
     """
-    list_display = ['admin_thumb', 'title', 'short_description', 'date_start', 'date_end']
+    list_display = ['admin_thumb', 'title', 'short_description', 'date_start', 'date_end', '_order']
     list_display_links = ['title', ]
     inlines = [ProjectImageInline, ReferenceStackedInline]
+    form = ProjectAdminForm
 
     def get_readonly_fields(self, request, obj=None):
         if obj:

--- a/django_project/kartoza_project/models/project.py
+++ b/django_project/kartoza_project/models/project.py
@@ -172,6 +172,9 @@ class Project(Orderable, Slugged, AdminThumbMixin):
     def __unicode__(self):
         return unicode(self.title)
 
+    class Meta:
+        ordering = ['-_order', '-date_end', '-date_start']
+
     @property
     def sorted_clients_set(self):
         return self.clients.order_by('title')


### PR DESCRIPTION
this fix https://github.com/kartoza/kartoza/issues/531

Enable "order" field to order the data
Order default value is pk, so we need to reorder it (put it manually)
The order is descending, so the big number for order is most top

The ordering on admin is same with the site
![Selection_049](https://user-images.githubusercontent.com/4530905/72952164-98d16c00-3dc3-11ea-8c58-2646d7242b59.png)

The field order
![Selection_050](https://user-images.githubusercontent.com/4530905/72952169-9a9b2f80-3dc3-11ea-888a-779b9e1f8e18.png)

The ordering on site is same with admin
![Selection_051](https://user-images.githubusercontent.com/4530905/72952275-ec43ba00-3dc3-11ea-9920-24f6dddfbe0f.png)

